### PR TITLE
Fix leaking of the EditForm CSS regarding the Message component to the main sites

### DIFF
--- a/src/components/EditForm/EditForm.css
+++ b/src/components/EditForm/EditForm.css
@@ -1,4 +1,4 @@
-.ui.message {
+.ui.message.social-blocks-message {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/EditForm/EditForm.jsx
+++ b/src/components/EditForm/EditForm.jsx
@@ -17,7 +17,7 @@ const EditForm = ({
 }) => {
   const error = invalidValue ? formErrorMessage : null;
   return (
-    <Message className="">
+    <Message className="social-blocks-message">
       <center>
         <Icon
           name={formIcon}


### PR DESCRIPTION
@ericof I don't know if the rest of CSS is also leaking... Also, we tend to group the CSS all together more than loading it as "side effect" per component. Could be that you were thinking in CSS modules in here? That could be done, although we never do it. But the syntax is different.